### PR TITLE
Prepare KMM production sample for Xcode 16

### DIFF
--- a/iosApp/iosApp/RSSApp.swift
+++ b/iosApp/iosApp/RSSApp.swift
@@ -11,11 +11,11 @@ import SwiftUI
 import RssReader
 
 @main
-class RSSApp: App {
+struct RSSApp: App {
     let rss: RssReader
     let store: ObservableFeedStore
     
-    required init() {
+    init() {
         rss = RssReader.Companion().create(withLog: true)
         store = ObservableFeedStore(store: FeedStore(rssReader: rss))
     }


### PR DESCRIPTION
Fixing builds with Xcode 16:
* Swift complaints about implicit self capture [here](https://github.com/Kotlin/kmm-production-sample/compare/master...abdulowork:kmm-production-sample:timofey.solonin/KT-70033-support-xcode16-kmm-production-sample?expand=1#diff-3da159631c6f3bd1f37d5fbc243d582a2aa700856728e90e12d2dfd768dff1f7R25)
* It seems with Xcode 16 `App` must be a struct because it otherwise explodes at runtime with:

<img width="749" alt="Screenshot 2024-07-31 at 2 23 21 PM" src="https://github.com/user-attachments/assets/ea3cc388-d408-4b1b-8975-87c9eca92aef">

Moving to struct also resolves the first issue